### PR TITLE
Add observation field

### DIFF
--- a/frontend/src/api/item.ts
+++ b/frontend/src/api/item.ts
@@ -6,6 +6,7 @@ export interface Item {
   active: boolean;
   createdAt: string;
   updatedAt: string;
+  observation?: string;
 }
 
 const BASE_URL = import.meta.env.VITE_API_URL ?? "/api";
@@ -21,13 +22,20 @@ export async function listItems(): Promise<Item[]> {
   return res.json();
 }
 
-export async function createItem(data: { name: string }): Promise<Item> {
+export async function createItem(data: {
+  name: string;
+  observation?: string;
+}): Promise<Item> {
   const res = await apiRequest(`${BASE_URL}/item`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({ name: data.name, active: true }),
+    body: JSON.stringify({
+      name: data.name,
+      active: true,
+      observation: data.observation,
+    }),
   });
   if (!res.ok) {
     const errorData = await res

--- a/frontend/src/components/ListItem.tsx
+++ b/frontend/src/components/ListItem.tsx
@@ -1,5 +1,5 @@
 import { Item } from "../api/item";
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import {
   FaCheckCircle,
   FaRegCircle,
@@ -7,6 +7,7 @@ import {
   FaTrash,
   FaCheck,
   FaTimes,
+  FaRegComment,
 } from "react-icons/fa";
 
 interface ListItemProps {
@@ -29,6 +30,16 @@ export const ListItem = React.memo(function ListItem({
   onCancelEdit,
 }: ListItemProps) {
   const contentEditableRef = useRef<HTMLDivElement>(null);
+  const observationRef = useRef<HTMLDivElement>(null);
+  const [isObservationExpanded, setIsObservationExpanded] = useState(false);
+  const [editedObservation, setEditedObservation] = useState(
+    item.observation || "",
+  );
+
+  // Resetar o estado da observação quando o item mudar
+  useEffect(() => {
+    setEditedObservation(item.observation || "");
+  }, [item.observation, item.id]);
 
   useEffect(() => {
     if (editingItemId === item.id && contentEditableRef.current) {
@@ -51,90 +62,206 @@ export const ListItem = React.memo(function ListItem({
   return (
     <li
       key={item.id}
-      className="flex items-center justify-between bg-white shadow-md rounded-lg p-4 transition-all duration-200 ease-in-out hover:shadow-lg"
+      className="flex flex-col bg-white shadow-md rounded-lg p-4 transition-all duration-200 ease-in-out hover:shadow-lg"
     >
-      <div
-        ref={contentEditableRef}
-        className={`flex-1 text-lg font-medium ${
-          item.active ? "text-gray-900" : "text-gray-500 line-through"
-        }`}
-        contentEditable={editingItemId === item.id}
-        suppressContentEditableWarning={true}
-        onKeyDown={(e) => {
-          if (e.key === "Enter") {
-            e.preventDefault();
+      {/* Linha principal: Nome + Ações */}
+      <div className="flex items-center justify-between">
+        <div
+          ref={contentEditableRef}
+          className={`flex-1 text-lg font-medium ${
+            item.active ? "text-gray-900" : "text-gray-500 line-through"
+          }`}
+          contentEditable={editingItemId === item.id}
+          suppressContentEditableWarning={true}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              const newName = e.currentTarget.innerText.trim();
+              if (newName) {
+                onSaveEdit({ ...item, name: newName });
+              } else {
+                onCancelEdit();
+              }
+            }
+            if (e.key === "Escape") {
+              e.preventDefault();
+              onCancelEdit();
+            }
+          }}
+          onBlur={(e) => {
+            // Verificar se o blur foi causado por clique no campo de observação ou botão de alternar
+            const relatedTarget = e.relatedTarget as HTMLElement;
+            const isObservationField = relatedTarget?.closest(
+              '[contenteditable="true"]',
+            );
+            const isObservationToggle = relatedTarget?.closest(
+              'button[aria-label="Alternar exibição da observação"]',
+            );
+
+            // Se clicou no campo de observação ou no botão de alternar, não fecha a edição
+            if (isObservationField || isObservationToggle) {
+              return;
+            }
+
             const newName = e.currentTarget.innerText.trim();
             if (newName) {
               onSaveEdit({ ...item, name: newName });
             } else {
               onCancelEdit();
             }
-          }
-          if (e.key === "Escape") {
-            e.preventDefault();
-            onCancelEdit();
-          }
-        }}
-        onBlur={(e) => {
-          const newName = e.currentTarget.innerText.trim();
-          if (newName) {
-            onSaveEdit({ ...item, name: newName });
-          } else {
-            onCancelEdit();
-          }
-        }}
-      >
-        {item.name}
-      </div>
-      <div className="flex items-center flex-wrap justify-end gap-2">
-        {editingItemId === item.id ? (
-          <>
-            <button
-              onClick={() => onSaveEdit(item)}
-              aria-label="Salvar edição"
-              className="p-2 bg-green-600 text-white rounded-md font-semibold hover:bg-green-700 transition-colors duration-200"
-            >
-              <FaCheck className="w-5 h-5" />
-            </button>
-            <button
-              onClick={onCancelEdit}
-              aria-label="Cancelar edição"
-              className="p-2 bg-gray-500 text-white rounded-md font-semibold hover:bg-gray-600 transition-colors duration-200"
-            >
-              <FaTimes className="w-5 h-5" />
-            </button>
-          </>
-        ) : (
-          <>
-            <button
-              onClick={() => onToggle(item)}
-              aria-pressed={item.active}
-              aria-label={item.active ? "Desmarcar item" : "Marcar item"}
-              className={`p-2 rounded-md text-white font-semibold transition-colors duration-200 ${item.active ? "bg-green-600 hover:bg-green-700" : "bg-yellow-600 hover:bg-yellow-700"}`}
-            >
-              {item.active ? (
-                <FaCheckCircle className="w-5 h-5" />
-              ) : (
-                <FaRegCircle className="w-5 h-5" />
+          }}
+        >
+          {item.name}
+        </div>
+        <div className="flex items-center flex-wrap justify-end gap-2">
+          {editingItemId === item.id ? (
+            <>
+              <button
+                onClick={() => onSaveEdit(item)}
+                aria-label="Salvar edição"
+                className="p-2 bg-green-600 text-white rounded-md font-semibold hover:bg-green-700 transition-colors duration-200"
+              >
+                <FaCheck className="w-5 h-5" />
+              </button>
+              <button
+                onClick={onCancelEdit}
+                aria-label="Cancelar edição"
+                className="p-2 bg-gray-500 text-white rounded-md font-semibold hover:bg-gray-600 transition-colors duration-200"
+              >
+                <FaTimes className="w-5 h-5" />
+              </button>
+            </>
+          ) : (
+            <>
+              <button
+                onClick={() => onToggle(item)}
+                aria-pressed={item.active}
+                aria-label={item.active ? "Desmarcar item" : "Marcar item"}
+                className={`p-2 rounded-md text-white font-semibold transition-colors duration-200 ${item.active ? "bg-green-600 hover:bg-green-700" : "bg-yellow-600 hover:bg-yellow-700"}`}
+              >
+                {item.active ? (
+                  <FaCheckCircle className="w-5 h-5" />
+                ) : (
+                  <FaRegCircle className="w-5 h-5" />
+                )}
+              </button>
+              <button
+                onClick={() => onEdit(item)}
+                aria-label="Editar item"
+                className="p-2 bg-blue-600 text-white rounded-md font-semibold hover:bg-blue-700 transition-colors duration-200"
+              >
+                <FaEdit className="w-5 h-5" />
+              </button>
+              <button
+                onClick={() => onDelete(item.id)}
+                aria-label="Excluir item"
+                className="p-2 bg-red-600 text-white rounded-md font-semibold hover:bg-red-700 transition-colors duration-200"
+              >
+                <FaTrash className="w-5 h-5" />
+              </button>
+              {/* Botão de toggle de observação - só aparece quando tem observação e não está editando */}
+              {item.observation && item.observation.length > 0 && (
+                <button
+                  onClick={() =>
+                    setIsObservationExpanded(!isObservationExpanded)
+                  }
+                  aria-label="Alternar exibição da observação"
+                  aria-expanded={isObservationExpanded}
+                  className={`p-2 rounded-md font-semibold transition-colors duration-200 ${
+                    isObservationExpanded
+                      ? "bg-purple-600 hover:bg-purple-700 text-white"
+                      : "bg-gray-200 hover:bg-gray-300 text-gray-600"
+                  }`}
+                >
+                  <FaRegComment className="w-5 h-5" />
+                </button>
               )}
-            </button>
-            <button
-              onClick={() => onEdit(item)}
-              aria-label="Editar item"
-              className="p-2 bg-blue-600 text-white rounded-md font-semibold hover:bg-blue-700 transition-colors duration-200"
-            >
-              <FaEdit className="w-5 h-5" />
-            </button>
-            <button
-              onClick={() => onDelete(item.id)}
-              aria-label="Excluir item"
-              className="p-2 bg-red-600 text-white rounded-md font-semibold hover:bg-red-700 transition-colors duration-200"
-            >
-              <FaTrash className="w-5 h-5" />
-            </button>
-          </>
-        )}
+            </>
+          )}
+        </div>
       </div>
+
+      {/* Seção de edição da observação - só aparece durante edição */}
+      {editingItemId === item.id && (
+        <div className="mt-3 border-t border-gray-200 pt-3">
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Observação (opcional)
+          </label>
+          <div
+            ref={observationRef}
+            className="outline-none min-h-[60px] p-2 border border-gray-300 rounded-md text-gray-900 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+            contentEditable={true}
+            suppressContentEditableWarning={true}
+            onInput={(e) => {
+              const text = e.currentTarget.innerText;
+              // Limitar a 200 caracteres sem atualizar estado
+              if (text.length > 200) {
+                e.currentTarget.innerText = text.slice(0, 200);
+                // Mover cursor para o final
+                const range = document.createRange();
+                const selection = window.getSelection();
+                range.selectNodeContents(e.currentTarget);
+                range.collapse(false);
+                selection?.removeAllRanges();
+                selection?.addRange(range);
+              }
+            }}
+            onBlur={(e) => {
+              // Verificar se o blur foi causado por clique no botão de cancelar
+              const relatedTarget = e.relatedTarget as HTMLElement;
+              const isCancelButton = relatedTarget?.closest(
+                'button[aria-label="Cancelar edição"]',
+              );
+
+              // Se clicou no botão de cancelar, não salva a observação
+              if (isCancelButton) {
+                return;
+              }
+
+              // Salvar a observação quando sair do campo (exceto ao cancelar)
+              const newObservation =
+                observationRef.current?.innerText.trim() || "";
+              if (newObservation !== item.observation) {
+                onSaveEdit({
+                  ...item,
+                  observation: newObservation || undefined,
+                });
+              }
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !e.shiftKey) {
+                e.preventDefault();
+                const newObservation =
+                  observationRef.current?.innerText.trim() || "";
+                onSaveEdit({
+                  ...item,
+                  observation: newObservation || undefined,
+                });
+              }
+            }}
+          >
+            {editedObservation}
+          </div>
+          <div className="text-xs text-gray-400 mt-1 text-right">
+            {editedObservation.length}/200
+          </div>
+        </div>
+      )}
+
+      {/* Painel de visualização da observação - só aparece quando expandido e não está editando */}
+      {editingItemId !== item.id &&
+        isObservationExpanded &&
+        item.observation &&
+        item.observation.length > 0 && (
+          <div className="mt-3 border-t border-gray-200 pt-3">
+            <div className="text-sm text-gray-700 bg-gray-50 p-3 rounded-lg">
+              <p className="whitespace-pre-wrap">{item.observation}</p>
+              <div className="text-xs text-gray-400 mt-2 text-right">
+                {item.observation.length}/200
+              </div>
+            </div>
+          </div>
+        )}
     </li>
   );
 });

--- a/frontend/src/components/__tests__/ListItem.test.tsx
+++ b/frontend/src/components/__tests__/ListItem.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { ListItem } from "../ListItem";
 import { Item } from "../../api/item";
 
@@ -78,5 +78,108 @@ describe("ListItem", () => {
 
     const itemText = screen.getByText("Test Item");
     expect(itemText).toHaveClass("line-through");
+  });
+
+  describe("Campo de Observação", () => {
+    it("Given_ItemWithObservation_When_Rendering_Then_ShowsObservationButton", () => {
+      const itemWithObs = {
+        ...mockItem,
+        observation: "Observação de teste",
+      };
+
+      render(
+        <ListItem
+          item={itemWithObs}
+          editingItemId={null}
+          onToggle={vi.fn()}
+          onDelete={vi.fn()}
+          onEdit={vi.fn()}
+          onSaveEdit={vi.fn()}
+          onCancelEdit={vi.fn()}
+        />,
+      );
+
+      expect(
+        screen.getByLabelText("Alternar exibição da observação"),
+      ).toBeInTheDocument();
+    });
+
+    it("Given_ItemWithoutObservation_When_Rendering_Then_DoesNotShowObservationButton", () => {
+      render(
+        <ListItem
+          item={mockItem}
+          editingItemId={null}
+          onToggle={vi.fn()}
+          onDelete={vi.fn()}
+          onEdit={vi.fn()}
+          onSaveEdit={vi.fn()}
+          onCancelEdit={vi.fn()}
+        />,
+      );
+
+      expect(
+        screen.queryByLabelText("Alternar exibição da observação"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("Given_ObservationExpanded_When_ClickingButton_Then_TogglesDisplay", () => {
+      const itemWithObs = {
+        ...mockItem,
+        observation: "Observação de teste",
+      };
+
+      render(
+        <ListItem
+          item={itemWithObs}
+          editingItemId={null}
+          onToggle={vi.fn()}
+          onDelete={vi.fn()}
+          onEdit={vi.fn()}
+          onSaveEdit={vi.fn()}
+          onCancelEdit={vi.fn()}
+        />,
+      );
+
+      const button = screen.getByLabelText("Alternar exibição da observação");
+
+      // Inicialmente a observação não está visível
+      expect(screen.queryByText("Observação de teste")).not.toBeInTheDocument();
+
+      // Clicar para expandir
+      fireEvent.click(button);
+
+      // Agora a observação deve estar visível
+      expect(screen.getByText("Observação de teste")).toBeInTheDocument();
+
+      // Clicar novamente para colapsar
+      fireEvent.click(button);
+
+      // Observação não deve estar mais visível
+      expect(screen.queryByText("Observação de teste")).not.toBeInTheDocument();
+    });
+
+    it("Given_ItemWithObservation_When_Rendering_Then_ShowsCharacterCount", () => {
+      const itemWithObs = {
+        ...mockItem,
+        observation: "Observação de teste",
+      };
+
+      render(
+        <ListItem
+          item={itemWithObs}
+          editingItemId={null}
+          onToggle={vi.fn()}
+          onDelete={vi.fn()}
+          onEdit={vi.fn()}
+          onSaveEdit={vi.fn()}
+          onCancelEdit={vi.fn()}
+        />,
+      );
+
+      const button = screen.getByLabelText("Alternar exibição da observação");
+      fireEvent.click(button);
+
+      expect(screen.getByText("19/200")).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/pages/ListPage.tsx
+++ b/frontend/src/pages/ListPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { FaCheck, FaPlus, FaTimes } from "react-icons/fa";
+import { FaCheck, FaPlus, FaTimes, FaRegComment } from "react-icons/fa";
 import { Item } from "../api/item";
 import ErrorBanner from "../components/ErrorBanner";
 import { ItemSkeleton } from "../components/ItemSkeleton";
@@ -21,7 +21,10 @@ export function ListPage() {
 
   const [isAddingNewItem, setIsAddingNewItem] = useState(false);
   const [newItemName, setNewItemName] = useState("");
+  const [newItemObservation, setNewItemObservation] = useState("");
+  const [isObservationExpanded, setIsObservationExpanded] = useState(false);
   const contentEditableNewItemRef = useRef<HTMLDivElement>(null);
+  const contentEditableObservationRef = useRef<HTMLDivElement>(null);
   const [editingItemId, setEditingItemId] = useState<string | null>(null);
 
   useEffect(() => {
@@ -66,26 +69,38 @@ export function ListPage() {
       isSubmittingRef.current = false;
       return;
     }
-    createItem.mutate(
-      { name: name },
-      {
-        onSuccess: () => {
-          setNewItemName("");
-          setIsAddingNewItem(false);
-          setIsSubmittingNewItem(false);
-          isSubmittingRef.current = false;
-        },
-        onError: () => {
-          setIsSubmittingNewItem(false);
-          isSubmittingRef.current = false;
-        },
+
+    // Preparar payload com observation - pegar valor direto do ref
+    const payload: { name: string; observation?: string } = { name };
+
+    // Só incluir observation se tiver valor
+    const observationValue =
+      contentEditableObservationRef.current?.innerText.trim() || "";
+    if (observationValue.length > 0) {
+      payload.observation = observationValue;
+    }
+
+    createItem.mutate(payload, {
+      onSuccess: () => {
+        setNewItemName("");
+        setNewItemObservation("");
+        setIsObservationExpanded(false);
+        setIsAddingNewItem(false);
+        setIsSubmittingNewItem(false);
+        isSubmittingRef.current = false;
       },
-    );
+      onError: () => {
+        setIsSubmittingNewItem(false);
+        isSubmittingRef.current = false;
+      },
+    });
   }, [createItem]);
 
   const handleCancelNewItem = useCallback(() => {
     setIsAddingNewItem(false);
     setNewItemName("");
+    setNewItemObservation("");
+    setIsObservationExpanded(false);
     setIsSubmittingNewItem(false);
     isSubmittingRef.current = false;
   }, []);
@@ -160,38 +175,137 @@ export function ListPage() {
       </div>
 
       {isAddingNewItem && (
-        <div className="relative w-full flex items-center bg-white shadow-md rounded-lg p-4 transition-all duration-200 ease-in-out hover:shadow-lg mb-3">
-          <div
-            ref={contentEditableNewItemRef}
-            className={`flex-1 text-lg font-medium outline-none ${
-              isSubmittingNewItem ? "text-gray-400" : "text-gray-900"
-            }`}
-            contentEditable={!isSubmittingNewItem}
-            suppressContentEditableWarning={true}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") {
-                e.preventDefault();
-                handleCreateSubmit();
-              }
-              if (e.key === "Escape") {
-                e.preventDefault();
-                handleCancelNewItem();
-              }
-            }}
-            onBlur={(e) => {
-              // Usa o ref síncrono para evitar race condition
-              if (createItem.isPending || isSubmittingRef.current) return;
-              const name = e.currentTarget.innerText.trim();
-              if (!name) {
-                handleCancelNewItem();
-              } else {
-                handleCreateSubmit();
-              }
-            }}
-          >
-            {newItemName || "\u00A0"}
+        <div className="relative w-full bg-white shadow-md rounded-lg p-4 transition-all duration-200 ease-in-out hover:shadow-lg mb-3">
+          {/* Campo Nome */}
+          <div className="flex items-center mb-2">
+            <div
+              ref={contentEditableNewItemRef}
+              className={`flex-1 text-lg font-medium outline-none ${
+                isSubmittingNewItem ? "text-gray-400" : "text-gray-900"
+              }`}
+              contentEditable={!isSubmittingNewItem}
+              suppressContentEditableWarning={true}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  handleCreateSubmit();
+                }
+                if (e.key === "Escape") {
+                  e.preventDefault();
+                  handleCancelNewItem();
+                }
+              }}
+              onBlur={(e) => {
+                // Usa o ref síncrono para evitar race condition
+                if (createItem.isPending || isSubmittingRef.current) return;
+
+                // Verifica se o blur foi causado por clique em elementos específicos
+                // O relatedTarget é o elemento que recebeu o foco
+                const relatedTarget = e.relatedTarget as HTMLElement;
+
+                // Não submete se clicou no botão cancelar, no campo de observação ou no botão de alternar observação
+                const isCancelButtonClicked = relatedTarget?.closest(
+                  'button[aria-label="Cancelar adição de item"]',
+                );
+                const isObservationField = relatedTarget?.closest(
+                  '[contenteditable="true"]',
+                );
+                const isObservationToggle = relatedTarget?.closest(
+                  'button[aria-label="Alternar campo de observação"]',
+                );
+
+                if (
+                  isCancelButtonClicked ||
+                  isObservationField ||
+                  isObservationToggle
+                ) {
+                  // Se clicou em qualquer um desses elementos, não submete automaticamente
+                  return;
+                }
+
+                const name = e.currentTarget.innerText.trim();
+                if (!name) {
+                  handleCancelNewItem();
+                } else {
+                  handleCreateSubmit();
+                }
+              }}
+            >
+              {newItemName || "\u00A0"}
+            </div>
           </div>
-          <div className="flex items-center flex-wrap justify-end gap-2 ml-2">
+
+          {/* Campo Observation Expandível */}
+          <div className="mb-2">
+            <button
+              onClick={() => setIsObservationExpanded(!isObservationExpanded)}
+              className="text-sm text-blue-600 hover:text-blue-800 flex items-center gap-1 mb-1"
+              aria-label="Alternar campo de observação"
+            >
+              <FaRegComment />
+              {isObservationExpanded
+                ? "Ocultar observação"
+                : "Adicionar observação"}
+            </button>
+
+            {isObservationExpanded && (
+              <div className="relative">
+                <div
+                  ref={contentEditableObservationRef}
+                  className="w-full min-h-[60px] p-2 border border-gray-300 rounded-md text-sm text-gray-900 outline-none focus:border-blue-500"
+                  contentEditable={!isSubmittingNewItem}
+                  suppressContentEditableWarning={true}
+                  onInput={(e) => {
+                    const text = e.currentTarget.innerText;
+                    // Limitar a 200 caracteres sem atualizar estado
+                    if (text.length > 200) {
+                      e.currentTarget.innerText = text.slice(0, 200);
+                      // Mover cursor para o final
+                      const range = document.createRange();
+                      const selection = window.getSelection();
+                      range.selectNodeContents(e.currentTarget);
+                      range.collapse(false);
+                      selection?.removeAllRanges();
+                      selection?.addRange(range);
+                    }
+                  }}
+                  onBlur={(e) => {
+                    // Usa o ref síncrono para evitar race condition
+                    if (createItem.isPending || isSubmittingRef.current) return;
+
+                    // Verifica se o blur foi causado por clique no botão cancelar ou adicionar
+                    const relatedTarget = e.relatedTarget as HTMLElement;
+                    const isCancelButtonClicked = relatedTarget?.closest(
+                      'button[aria-label="Cancelar adição de item"]',
+                    );
+                    const isAddButtonClicked = relatedTarget?.closest(
+                      'button[aria-label="Adicionar item"]',
+                    );
+
+                    // Se clicou nos botões, não faz nada (eles vão tratar a ação)
+                    if (isCancelButtonClicked || isAddButtonClicked) {
+                      return;
+                    }
+
+                    // Se saiu do campo de observação, submete o formulário
+                    const name =
+                      contentEditableNewItemRef.current?.innerText.trim() || "";
+                    if (name) {
+                      handleCreateSubmit();
+                    }
+                  }}
+                >
+                  {newItemObservation}
+                </div>
+                <div className="text-xs text-gray-500 mt-1 text-right">
+                  {newItemObservation.length}/200 caracteres
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Botões de Ação */}
+          <div className="flex items-center flex-wrap justify-end gap-2">
             <button
               onClick={handleCreateSubmit}
               disabled={isSubmittingNewItem}


### PR DESCRIPTION
## Summary
- Adicionado campo de observação opcional nos itens
- Refatorada exibição de observações para manter altura consistente dos itens
- Observação oculta por padrão e exibida através de botão de ícone

## Changes
- Adicionado campo `observation?: string` na interface Item
- Botão de toggle de observação na barra de ações (ícone roxo quando expandido)
- Seção de edição da observação aparece durante edição do item
- Painel de visualização simples só mostra quando expandido
- Corrigido bug de salvamento ao clicar em cancelar

## Test plan
- [x] Criar itens com e sem observação
- [x] Verificar altura consistente dos itens quando observação está recolhida
- [x] Testar toggle de expandir/recolher observação
- [x] Testar edição de item com observação
- [x] Testar cancelamento de edição (não deve salvar observação)
- [x] Executar testes: `npm test`
- [x] Executar lint: `npm run lint`